### PR TITLE
EXT-X-IFRAME-STREAM-INF are not properly written

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,18 @@ if (playlist.hasMasterPlaylist() && playlist.getMasterPlaylist().hasUnknownTags(
     System.out.println("Parsing without unknown tags successful");
 }
 ```
+
+=======
+## Build
+
+This is a Gradle 2.1 project. Build via
+```
+gradle build
+```
+which also executes the unit tests.
+
+Cobertura is configured to report the line coverage:
+```
+gradle cobertura
+```
+producing the coverage report at `build/reports/cobertura/index.html`

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,18 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+    }
+}
+plugins {
+    id 'net.saliman.cobertura' version '2.2.7'
+}
+repositories {
+    mavenCentral()
+}
+
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'maven'
@@ -9,20 +24,6 @@ idea {
         downloadSources = true
     }
 }
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-    }
-}
-
-repositories {
-    mavenCentral()
-}
-
 group 'com.iheartradio.m3u8'
 archivesBaseName = 'open-m3u8'
 sourceCompatibility = 1.7
@@ -30,6 +31,8 @@ version '0.1.0'
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
+	testRuntime "org.slf4j:slf4j-log4j12:1.7.5"
+    testRuntime "log4j:log4j:1.2.7"
 }
 
 task javadocJar(type: Jar) {

--- a/src/main/java/com/iheartradio/m3u8/MasterPlaylistTagParser.java
+++ b/src/main/java/com/iheartradio/m3u8/MasterPlaylistTagParser.java
@@ -260,10 +260,10 @@ abstract class MasterPlaylistTagParser extends ExtTagParser {
                 throw new ParseException(ParseExceptionType.MISSING_STREAM_BANDWIDTH, getTag());
             }
             
-            handle(builder, state, streamInfo);
+            doParse(builder, state, streamInfo);
         }
         
-        protected abstract void handle(Builder builder, ParseState state, StreamInfo streamInfo) throws ParseException;
+        protected abstract void doParse(Builder builder, ParseState state, StreamInfo streamInfo) throws ParseException;
 
     }
     
@@ -278,7 +278,7 @@ abstract class MasterPlaylistTagParser extends ExtTagParser {
             });
         }
         
-        protected void handle(Builder streamBuilder, ParseState state, StreamInfo streamInfo) throws ParseException {
+        protected void doParse(Builder streamBuilder, ParseState state, StreamInfo streamInfo) throws ParseException {
 
             if (!streamBuilder.isUriSet()) {
                 throw new ParseException(ParseExceptionType.MISSING_STREAM_URI, getTag());
@@ -296,7 +296,7 @@ abstract class MasterPlaylistTagParser extends ExtTagParser {
             final MasterParseState masterState = state.getMaster();
 
             masterState.playlists.add(builder
-                    .withStreamInfo(masterState.streamInfo)
+                    .withStreamInfo(streamInfo)
                     .build());
         };
         
@@ -333,7 +333,7 @@ abstract class MasterPlaylistTagParser extends ExtTagParser {
             });    
         }
         
-        protected void handle(Builder builder, ParseState state, StreamInfo streamInfo) {
+        protected void doParse(Builder builder, ParseState state, StreamInfo streamInfo) {
             state.getMaster().streamInfo = streamInfo;
         };
         

--- a/src/main/java/com/iheartradio/m3u8/MasterPlaylistTagWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/MasterPlaylistTagWriter.java
@@ -1,14 +1,28 @@
 package com.iheartradio.m3u8;
 
+import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import com.iheartradio.m3u8.data.MasterPlaylist;
 import com.iheartradio.m3u8.data.MediaData;
+import com.iheartradio.m3u8.data.Playlist;
 import com.iheartradio.m3u8.data.PlaylistData;
 import com.iheartradio.m3u8.data.StreamInfo;
-import com.iheartradio.m3u8.data.StreamInfo.Builder;
 
 abstract class MasterPlaylistTagWriter extends ExtTagWriter {
+    
+    @Override
+    public final void write(TagWriter tagWriter, Playlist playlist) throws IOException, ParseException {
+        if (playlist.hasMasterPlaylist()) {
+            doWrite(tagWriter, playlist, playlist.getMasterPlaylist());
+        }
+    }
+    
+    public void doWrite(TagWriter tagWriter,Playlist playlist, MasterPlaylist masterPlaylist) throws IOException, ParseException {
+        tagWriter.writeTag(getTag());
+    }
     
     // master playlist tags
 
@@ -160,6 +174,16 @@ abstract class MasterPlaylistTagWriter extends ExtTagWriter {
         boolean hasData() {
             return true;
         }
+        
+        @Override
+        public void doWrite(TagWriter tagWriter, Playlist playlist, MasterPlaylist masterPlaylist) throws IOException, ParseException {
+            if (masterPlaylist.getMediaData().size() > 0) {
+                List<MediaData> mds = masterPlaylist.getMediaData();
+                for(MediaData md : mds) {
+                    writeAttributes(tagWriter, md, HANDLERS);
+                }
+            }
+        }
     };
 
     static abstract class EXT_STREAM_INF extends MasterPlaylistTagWriter {
@@ -222,7 +246,7 @@ abstract class MasterPlaylistTagWriter extends ExtTagWriter {
                 
                 @Override
                 public String write(StreamInfo streamInfo) throws ParseException {
-                    return ParseUtil.parseQuotedString(streamInfo.getVideo(), getTag());
+                    return WriteUtil.writeQuotedString(streamInfo.getVideo(), getTag());
                 }
             });
 
@@ -244,9 +268,8 @@ abstract class MasterPlaylistTagWriter extends ExtTagWriter {
         boolean hasData() {
             return true;
         }
-
-        protected abstract void handle(Builder builder, ParseState state, StreamInfo streamInfo) throws ParseException;
-
+        
+        public abstract void doWrite(TagWriter tagWriter, Playlist playlist, MasterPlaylist masterPlaylist) throws IOException, ParseException;
     }
     
     static final IExtTagWriter EXT_X_I_FRAME_STREAM_INF = new EXT_STREAM_INF() {
@@ -265,32 +288,21 @@ abstract class MasterPlaylistTagWriter extends ExtTagWriter {
             });
         }
         
-        protected void handle(Builder streamBuilder, ParseState state, StreamInfo streamInfo) throws ParseException {
-
-            if (!streamBuilder.isUriSet()) {
-                throw new ParseException(ParseExceptionType.MISSING_STREAM_URI, getTag());
-            }
-            String line = streamInfo.getUri();
-            
-            final PlaylistData.Builder builder = new PlaylistData.Builder();
-
-            if (Constants.URL_PATTERN.matcher(line).matches()) {
-                builder.withUrl(line);
-            } else {
-                builder.withPath(line);
-            }
-            
-            final MasterParseState masterState = state.getMaster();
-
-            masterState.playlists.add(builder
-                    .withStreamInfo(masterState.streamInfo)
-                    .build());
-        };
-        
         @Override
         public String getTag() {
             return Constants.EXT_X_I_FRAME_STREAM_INF_TAG;
-        } 
+        }
+        
+        @Override
+        public void doWrite(TagWriter tagWriter, Playlist playlist, MasterPlaylist masterPlaylist) throws IOException, ParseException {
+            if (masterPlaylist.getPlaylists().size() > 0) {
+                for(PlaylistData pd : masterPlaylist.getPlaylists()) {
+                    if (pd.getStreamInfo().hasUri()) {
+                        writeAttributes(tagWriter, pd.getStreamInfo(), HANDLERS);
+                    }
+                }
+            }
+        };
     };
     
     static final IExtTagWriter EXT_X_STREAM_INF = new EXT_STREAM_INF() {
@@ -332,13 +344,21 @@ abstract class MasterPlaylistTagWriter extends ExtTagWriter {
             });    
         }
         
-        protected void handle(Builder builder, ParseState state, StreamInfo streamInfo) {
-            state.getMaster().streamInfo = streamInfo;
-        };
-        
         @Override
         public String getTag() {
             return Constants.EXT_X_STREAM_INF_TAG;
         }
+        
+        @Override
+        public void doWrite(TagWriter tagWriter, Playlist playlist, MasterPlaylist masterPlaylist) throws IOException, ParseException {
+            if (masterPlaylist.getPlaylists().size() > 0) {
+                for(PlaylistData pd : masterPlaylist.getPlaylists()) {
+                    if (!pd.getStreamInfo().hasUri()) {
+                        writeAttributes(tagWriter, pd.getStreamInfo(), HANDLERS);
+                        tagWriter.writeLine(pd.getLocation());
+                    }
+                }
+            }
+        };
     };
 }

--- a/src/test/java/com/iheartradio/m3u8/PlaylistParserWriterTest.java
+++ b/src/test/java/com/iheartradio/m3u8/PlaylistParserWriterTest.java
@@ -4,11 +4,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import com.iheartradio.m3u8.data.MasterPlaylist;
 import com.iheartradio.m3u8.data.Playlist;
+import com.iheartradio.m3u8.data.PlaylistData;
 
 import static org.junit.Assert.*;
 
@@ -81,10 +84,79 @@ public class PlaylistParserWriterTest {
     @Test
     public void masterPlaylistWithIFrames() throws IOException, ParseException {
         Playlist playlist = readPlaylist("masterPlaylistWithIFrames.m3u8");
+        assertTrue(playlist.hasMasterPlaylist());
         
-        String sPlaylist = writePlaylist(playlist);
+        MasterPlaylist masterPlaylist = playlist.getMasterPlaylist();
+        assertNotNull(masterPlaylist);
         
-        System.out.println(sPlaylist);
+        List<PlaylistData> playlistDatas = masterPlaylist.getPlaylists();
+        assertNotNull(playlistDatas);
+        assertEquals(7, playlistDatas.size());
+        
+        PlaylistData lowXStreamInf = playlistDatas.get(0);
+        assertNotNull(lowXStreamInf);
+        assertNotNull(lowXStreamInf.getStreamInfo());
+        assertEquals(1280000, lowXStreamInf.getStreamInfo().getBandwidth());
+        assertEquals("low/audio-video.m3u8", lowXStreamInf.getLocation());
+        assertNull(lowXStreamInf.getStreamInfo().getUri());
+        
+        PlaylistData lowXIFrameStreamInf = playlistDatas.get(1);
+        assertNotNull(lowXIFrameStreamInf);
+        assertNotNull(lowXIFrameStreamInf.getStreamInfo());
+        assertEquals(86000, lowXIFrameStreamInf.getStreamInfo().getBandwidth());
+        assertEquals("low/iframe.m3u8", lowXIFrameStreamInf.getStreamInfo().getUri());
+
+        PlaylistData midXStreamInf = playlistDatas.get(2);
+        assertNotNull(midXStreamInf);
+        assertNotNull(midXStreamInf.getStreamInfo());
+        assertEquals(2560000, midXStreamInf.getStreamInfo().getBandwidth());
+        assertEquals("mid/audio-video.m3u8", midXStreamInf.getLocation());
+        assertNull(midXStreamInf.getStreamInfo().getUri());
+
+        PlaylistData midXIFrameStreamInf = playlistDatas.get(3);
+        assertNotNull(midXIFrameStreamInf);
+        assertNotNull(midXIFrameStreamInf.getStreamInfo());
+        assertEquals(150000, midXIFrameStreamInf.getStreamInfo().getBandwidth());
+        assertEquals("mid/iframe.m3u8", midXIFrameStreamInf.getStreamInfo().getUri());
+
+        PlaylistData hiXStreamInf = playlistDatas.get(4);
+        assertNotNull(hiXStreamInf);
+        assertNotNull(hiXStreamInf.getStreamInfo());
+        assertEquals(7680000, hiXStreamInf.getStreamInfo().getBandwidth());
+        assertEquals("hi/audio-video.m3u8", hiXStreamInf.getLocation());
+        assertNull(hiXStreamInf.getStreamInfo().getUri());
+
+        PlaylistData hiXIFrameStreamInf = playlistDatas.get(5);
+        assertNotNull(hiXIFrameStreamInf);
+        assertNotNull(hiXIFrameStreamInf.getStreamInfo());
+        assertEquals(550000, hiXIFrameStreamInf.getStreamInfo().getBandwidth());
+        assertEquals("hi/iframe.m3u8", hiXIFrameStreamInf.getStreamInfo().getUri());
+
+        PlaylistData audioXStreamInf = playlistDatas.get(6);
+        assertNotNull(audioXStreamInf);
+        assertNotNull(audioXStreamInf.getStreamInfo());
+        assertEquals(65000, audioXStreamInf.getStreamInfo().getBandwidth());
+        assertNotNull(audioXStreamInf.getStreamInfo().getCodecs());
+        assertEquals(1, audioXStreamInf.getStreamInfo().getCodecs().size());
+        assertEquals("mp4a.40.5", audioXStreamInf.getStreamInfo().getCodecs().get(0));
+        assertEquals("audio-only.m3u8", audioXStreamInf.getLocation());
+        assertNull(audioXStreamInf.getStreamInfo().getUri());
+        
+        String writtenPlaylist = writePlaylist(playlist);
+        assertEquals("#EXTM3U\n" +
+                "#EXT-X-VERSION:1\n" +
+                "#EXT-X-STREAM-INF:BANDWIDTH=1280000\n" +
+                "low/audio-video.m3u8\n" +
+                "#EXT-X-STREAM-INF:BANDWIDTH=2560000\n" +
+                "mid/audio-video.m3u8\n" +
+                "#EXT-X-STREAM-INF:BANDWIDTH=7680000\n" +
+                "hi/audio-video.m3u8\n" +
+                "#EXT-X-STREAM-INF:CODECS=\"mp4a.40.5\",BANDWIDTH=65000\n" +
+                "audio-only.m3u8\n" +
+                "#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=86000,URI=\"low/iframe.m3u8\"\n" +
+                "#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=150000,URI=\"mid/iframe.m3u8\"\n" +
+                "#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=550000,URI=\"hi/iframe.m3u8\"\n",
+                writtenPlaylist);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes the proper handling of EXT-X-IFRAME-STREAM-INF tags and includes a unit test to prove the functionality.

For better testing support, cobertura was added to the build file, too.