### PR TITLE
Updates for support of media playlist tag EXT-X-PROGRAM-DATE-TIME.

### DIFF
--- a/src/main/java/com/iheartradio/m3u8/Constants.java
+++ b/src/main/java/com/iheartradio/m3u8/Constants.java
@@ -58,6 +58,7 @@ final class Constants {
     // media playlist tags
     
     public static final String EXT_X_PLAYLIST_TYPE_TAG = "EXT-X-PLAYLIST-TYPE";
+    public static final String EXT_X_PROGRAM_DATE_TIME_TAG = "EXT-X-PROGRAM-DATE-TIME";
     public static final String EXT_X_TARGETDURATION_TAG = "EXT-X-TARGETDURATION";
     public static final String EXT_X_START_TAG = "EXT-X-START";
     public static final String TIME_OFFSET = "TIME-OFFSET";
@@ -83,6 +84,7 @@ final class Constants {
     public static final String NO = "NO";
     private static final String INTEGER_REGEX = "\\d+";
     private static final String SIGNED_FLOAT_REGEX = "-?\\d*\\.?\\d*";
+    private static final String TIMESTAMP_REGEX = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z";
 
     public static final Pattern HEXADECIMAL_PATTERN = Pattern.compile("^0[x|X]([0-9A-F]+)$");
     public static final Pattern RESOLUTION_PATTERN = Pattern.compile("^(" + INTEGER_REGEX + ")x(" + INTEGER_REGEX + ")$");
@@ -91,6 +93,7 @@ final class Constants {
     public static final Pattern EXT_X_TARGETDURATION_PATTERN = Pattern.compile("^#" + EXT_X_TARGETDURATION_TAG + EXT_TAG_END + "(" + INTEGER_REGEX + ")$");
     public static final Pattern EXT_X_MEDIA_SEQUENCE_PATTERN = Pattern.compile("^#" + EXT_X_MEDIA_SEQUENCE_TAG + EXT_TAG_END + "(" + INTEGER_REGEX + ")$");
     public static final Pattern EXT_X_PLAYLIST_TYPE_PATTERN  = Pattern.compile("^#" + EXT_X_PLAYLIST_TYPE_TAG + EXT_TAG_END + "(EVENT|VOD)$");
+    public static final Pattern EXT_X_PROGRAM_DATE_TIME_PATTERN  = Pattern.compile("^#" + EXT_X_PROGRAM_DATE_TIME_TAG + EXT_TAG_END + "(" + TIMESTAMP_REGEX + ")$");
     public static final Pattern EXT_X_MEDIA_IN_STREAM_ID_PATTERN = Pattern.compile("^CC[1-4]|SERVICE(?:[1-9]|[1-5]\\d|6[0-3])$");
     public static final Pattern EXTINF_PATTERN = Pattern.compile("^#" + EXTINF_TAG + EXT_TAG_END + "(" + SIGNED_FLOAT_REGEX + ")(?:,(.+)?)?$");
     public static final Pattern EXT_X_ENDLIST_PATTERN = Pattern.compile("^#" + EXT_X_ENDLIST_TAG + "$");

--- a/src/main/java/com/iheartradio/m3u8/Constants.java
+++ b/src/main/java/com/iheartradio/m3u8/Constants.java
@@ -84,13 +84,7 @@ final class Constants {
     public static final String NO = "NO";
     private static final String INTEGER_REGEX = "\\d+";
     private static final String SIGNED_FLOAT_REGEX = "-?\\d*\\.?\\d*";
-    // TIMESTAMP_REGEX accepts time strings of format:
-    // 1970-01-01T00:00:00
-    // 1970-01-01T00:00:00Z
-    // 1970-01-01T00:00:00.000
-    // 1970-01-01T00:00:00+00:00
-    // 1970-01-01T00:00:00.000+00:00
-    private static final String TIMESTAMP_REGEX = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?(\\.\\d{3})?(\\+\\d{2}:\\d{2})?";
+    private static final String TIMESTAMP_REGEX = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?(?:Z?|\\+\\d{2}:\\d{2})?";
 
     public static final Pattern HEXADECIMAL_PATTERN = Pattern.compile("^0[x|X]([0-9A-F]+)$");
     public static final Pattern RESOLUTION_PATTERN = Pattern.compile("^(" + INTEGER_REGEX + ")x(" + INTEGER_REGEX + ")$");

--- a/src/main/java/com/iheartradio/m3u8/Constants.java
+++ b/src/main/java/com/iheartradio/m3u8/Constants.java
@@ -84,7 +84,13 @@ final class Constants {
     public static final String NO = "NO";
     private static final String INTEGER_REGEX = "\\d+";
     private static final String SIGNED_FLOAT_REGEX = "-?\\d*\\.?\\d*";
-    private static final String TIMESTAMP_REGEX = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z";
+    // TIMESTAMP_REGEX accepts time strings of format:
+    // 1970-01-01T00:00:00
+    // 1970-01-01T00:00:00Z
+    // 1970-01-01T00:00:00.000
+    // 1970-01-01T00:00:00+00:00
+    // 1970-01-01T00:00:00.000+00:00
+    private static final String TIMESTAMP_REGEX = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?(\\.\\d{3})?(\\+\\d{2}:\\d{2})?";
 
     public static final Pattern HEXADECIMAL_PATTERN = Pattern.compile("^0[x|X]([0-9A-F]+)$");
     public static final Pattern RESOLUTION_PATTERN = Pattern.compile("^(" + INTEGER_REGEX + ")x(" + INTEGER_REGEX + ")$");

--- a/src/main/java/com/iheartradio/m3u8/ExtendedM3uParser.java
+++ b/src/main/java/com/iheartradio/m3u8/ExtendedM3uParser.java
@@ -20,6 +20,7 @@ class ExtendedM3uParser extends BaseM3uParser {
                 ExtLineParser.EXTM3U_HANDLER,
                 ExtLineParser.EXT_X_VERSION_HANDLER,
                 MediaPlaylistLineParser.EXT_X_PLAYLIST_TYPE,
+                MediaPlaylistLineParser.EXT_X_PROGRAM_DATE_TIME,
                 MediaPlaylistLineParser.EXT_X_KEY,
                 MediaPlaylistLineParser.EXT_X_TARGETDURATION,
                 MediaPlaylistLineParser.EXT_X_START,

--- a/src/main/java/com/iheartradio/m3u8/MediaParseState.java
+++ b/src/main/java/com/iheartradio/m3u8/MediaParseState.java
@@ -21,6 +21,7 @@ class MediaParseState implements IParseState<MediaPlaylist> {
     public TrackInfo trackInfo;
     public EncryptionData encryptionData;
     public StartData startData;
+    public String playlistDateTime;
     public boolean endOfList;
     public boolean hasDiscontinuity;
 

--- a/src/main/java/com/iheartradio/m3u8/MediaPlaylistLineParser.java
+++ b/src/main/java/com/iheartradio/m3u8/MediaPlaylistLineParser.java
@@ -114,6 +114,33 @@ class MediaPlaylistLineParser implements LineParser {
         }
     };
     
+    static final IExtTagParser EXT_X_PROGRAM_DATE_TIME = new IExtTagParser() {
+        private final LineParser lineParser = new MediaPlaylistLineParser(this);
+
+        @Override
+        public String getTag() {
+            return Constants.EXT_X_PROGRAM_DATE_TIME_TAG;
+        }
+
+        @Override
+        public boolean hasData() {
+            return true;
+        }
+        
+        @Override
+        public void parse(String line, ParseState state) throws ParseException {
+            lineParser.parse(line, state);
+
+            final Matcher matcher = ParseUtil.match(Constants.EXT_X_PROGRAM_DATE_TIME_PATTERN, line, getTag());
+
+            if (state.getMedia().playlistDateTime != null) {
+                throw ParseException.create(ParseExceptionType.MULTIPLE_EXT_TAG_INSTANCES, getTag(), line);
+            }
+
+            state.getMedia().playlistDateTime = ParseUtil.parseDateTime(line,getTag());
+        }
+    };
+    
     static final IExtTagParser EXT_X_START = new IExtTagParser() {
         private final LineParser lineParser = new MediaPlaylistLineParser(this);
         private final Map<String, AttributeParser<StartData.Builder>> HANDLERS = new HashMap<>();

--- a/src/main/java/com/iheartradio/m3u8/ParseExceptionType.java
+++ b/src/main/java/com/iheartradio/m3u8/ParseExceptionType.java
@@ -18,6 +18,7 @@ public enum ParseExceptionType {
     INVALID_MEDIA_TYPE("invalid media TYPE"),
     INVALID_RESOLUTION_FORMAT("a resolution was not formatted properly"),
     INVALID_QUOTED_STRING("a quoted string was not properly formatted"),
+    INVALID_DATE_TIME_FORMAT("a date-time string was not properly formatted"),
     MASTER_IN_MEDIA("master playlist tags we found in a media playlist"),
     MEDIA_IN_MASTER("media playlist tags we found in a master playlist"),
     MISSING_ATTRIBUTE_NAME("missing the name of an attribute"),

--- a/src/main/java/com/iheartradio/m3u8/ParseUtil.java
+++ b/src/main/java/com/iheartradio/m3u8/ParseUtil.java
@@ -29,6 +29,16 @@ final class ParseUtil {
             throw ParseException.create(ParseExceptionType.NOT_JAVA_ENUM, tag, string);
         }
     }
+    
+    public static String parseDateTime(String string, String tag) throws ParseException {
+        Matcher matcher = Constants.EXT_X_PROGRAM_DATE_TIME_PATTERN.matcher(string);
+
+        if (!matcher.matches()) {
+            throw new ParseException(ParseExceptionType.INVALID_DATE_TIME_FORMAT, tag);
+        }
+
+        return matcher.group(1);
+    }
 
     public static float parseFloat(String string, String tag) throws ParseException {
         try {


### PR DESCRIPTION
IExtTagParser EXT_X_PROGRAM_DATE_TIME in MediaPlaylistLineParser.java may not be how iheartradio envisioned, but this works when set in 'strict' parse mode (tested with a playlist I have containing EXT_X_PROGRAM_DATE_TIME).