### PR TITLE
Applied EXT-X-KEY for each media segment in the writer.

### DIFF
--- a/src/main/java/com/iheartradio/m3u8/ExtendedM3uWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/ExtendedM3uWriter.java
@@ -3,12 +3,13 @@ package com.iheartradio.m3u8;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.iheartradio.m3u8.data.Playlist;
 
 class ExtendedM3uWriter extends Writer {
-    private List<IExtTagWriter> mExtTagWriter = new ArrayList<IExtTagWriter>();
+    private List<SectionWriter> mExtTagWriter = new ArrayList<SectionWriter>();
 
     public ExtendedM3uWriter(OutputStream outputStream, Encoding encoding) {
         super(outputStream, encoding);
@@ -17,7 +18,6 @@ class ExtendedM3uWriter extends Writer {
                 ExtTagWriter.EXTM3U_HANDLER,
                 ExtTagWriter.EXT_X_VERSION_HANDLER,
                 MediaPlaylistTagWriter.EXT_X_PLAYLIST_TYPE,
-                MediaPlaylistTagWriter.EXT_X_KEY,
                 MediaPlaylistTagWriter.EXT_X_TARGETDURATION,
                 MediaPlaylistTagWriter.EXT_X_START,
                 MediaPlaylistTagWriter.EXT_X_MEDIA_SEQUENCE,
@@ -26,22 +26,20 @@ class ExtendedM3uWriter extends Writer {
                 MediaPlaylistTagWriter.EXT_X_ALLOW_CACHE,
                 MasterPlaylistTagWriter.EXT_X_STREAM_INF,
                 MasterPlaylistTagWriter.EXT_X_I_FRAME_STREAM_INF,
-                MediaPlaylistTagWriter.EXTINF,
+                MediaPlaylistTagWriter.MEDIA_SEGMENTS,
                 MediaPlaylistTagWriter.EXT_X_ENDLIST
         );
     }
 
-    private void putWriters(IExtTagWriter... writers) {
+    private void putWriters(SectionWriter... writers) {
         if (writers != null) {
-            for (IExtTagWriter writer : writers) {
-                mExtTagWriter.add(writer);
-            }
+            Collections.addAll(mExtTagWriter, writers);
         }
     }
 
     @Override
     void doWrite(Playlist playlist) throws IOException, ParseException, PlaylistException {
-        for (IExtTagWriter singleTagWriter : mExtTagWriter) {
+        for (SectionWriter singleTagWriter : mExtTagWriter) {
             singleTagWriter.write(tagWriter, playlist);
         }
     }

--- a/src/main/java/com/iheartradio/m3u8/IExtTagWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/IExtTagWriter.java
@@ -1,11 +1,5 @@
 package com.iheartradio.m3u8;
 
-import java.io.IOException;
-
-import com.iheartradio.m3u8.data.Playlist;
-
-interface IExtTagWriter {
+interface IExtTagWriter extends SectionWriter {
     String getTag();
-    
-    void write(TagWriter tagWriter, Playlist playlist) throws IOException, ParseException;
 }

--- a/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
@@ -226,7 +226,7 @@ abstract class MediaPlaylistTagWriter extends ExtTagWriter {
     static class KeyWriter extends MediaPlaylistTagWriter {
         private final Map<String, AttributeWriter<EncryptionData>> HANDLERS = new HashMap<String, AttributeWriter<EncryptionData>>();
 
-        private TrackData mTrackData;
+        private EncryptionData mEncryptionData;
 
         {
             HANDLERS.put(Constants.METHOD, new AttributeWriter<EncryptionData>() {
@@ -304,14 +304,18 @@ abstract class MediaPlaylistTagWriter extends ExtTagWriter {
 
         @Override
         public void doWrite(TagWriter tagWriter, Playlist playlist, MediaPlaylist mediaPlaylist) throws IOException, ParseException {
-            if (mTrackData != null && mTrackData.hasEncryptionData()) {
-                writeAttributes(tagWriter, mTrackData.getEncryptionData(), HANDLERS);
-            }
+            writeAttributes(tagWriter, mEncryptionData, HANDLERS);
         }
 
         void writeTrackData(TagWriter tagWriter, Playlist playlist, TrackData trackData) throws IOException, ParseException {
-            mTrackData = trackData;
-            write(tagWriter, playlist);
+            if (trackData != null && trackData.hasEncryptionData()) {
+                final EncryptionData encryptionData = trackData.getEncryptionData();
+
+                if (!encryptionData.equals(mEncryptionData)) {
+                    mEncryptionData = encryptionData;
+                    write(tagWriter, playlist);
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
@@ -188,40 +188,45 @@ abstract class MediaPlaylistTagWriter extends ExtTagWriter {
 
     // media segment tags
 
-    static final IExtTagWriter EXTINF = new MediaPlaylistTagWriter() {
+    static final SectionWriter MEDIA_SEGMENTS = new SectionWriter() {
         @Override
-        public String getTag() {
-            return Constants.EXTINF_TAG;
-        }
+        public void write(TagWriter tagWriter, Playlist playlist) throws IOException, ParseException {
+            if (playlist.hasMediaPlaylist()) {
+                KeyWriter keyWriter = new KeyWriter();
 
-        @Override
-        boolean hasData() {
-            return true;
-        }
-        
-        @Override
-        public void doWrite(TagWriter tagWriter, Playlist playlist, MediaPlaylist mediaPlaylist) throws IOException ,ParseException {
-            for (TrackData trackData : mediaPlaylist.getTracks()) {
-                StringBuilder sb = new StringBuilder();
-                if (playlist.getCompatibilityVersion() <= 3) {
-                    sb.append(Integer.toString((int)trackData.getTrackInfo().duration));
-                } else {
-                    sb.append(Float.toString(trackData.getTrackInfo().duration));
+                for (TrackData trackData : playlist.getMediaPlaylist().getTracks()) {
+                    if (trackData.hasDiscontinuity()) {
+                        tagWriter.writeTag(Constants.EXT_X_DISCONTINUITY_TAG);
+                    }
+
+                    keyWriter.writeTrackData(tagWriter, playlist, trackData);
+                    writeExtinf(tagWriter, playlist, trackData);
+                    tagWriter.writeLine(trackData.getUri());
                 }
-                if (trackData.getTrackInfo().title != null) {
-                    sb.append(Constants.COMMA).append(trackData.getTrackInfo().title);
-                }
-                if (trackData.hasDiscontinuity()) {
-                    tagWriter.writeTag(Constants.EXT_X_DISCONTINUITY_TAG);
-                }
-                tagWriter.writeTag(getTag(), sb.toString());
-                tagWriter.writeLine(trackData.getUri());
             }
-        };
+        }
     };
 
-    static final ExtTagWriter EXT_X_KEY = new MediaPlaylistTagWriter() {
+    private static void writeExtinf(TagWriter tagWriter, Playlist playlist, TrackData trackData) throws IOException {
+        final StringBuilder builder = new StringBuilder();
+
+        if (playlist.getCompatibilityVersion() <= 3) {
+            builder.append(Integer.toString((int) trackData.getTrackInfo().duration));
+        } else {
+            builder.append(Float.toString(trackData.getTrackInfo().duration));
+        }
+
+        if (trackData.getTrackInfo().title != null) {
+            builder.append(Constants.COMMA).append(trackData.getTrackInfo().title);
+        }
+
+        tagWriter.writeTag(Constants.EXTINF_TAG, builder.toString());
+    }
+
+    static class KeyWriter extends MediaPlaylistTagWriter {
         private final Map<String, AttributeWriter<EncryptionData>> HANDLERS = new HashMap<String, AttributeWriter<EncryptionData>>();
+
+        private TrackData mTrackData;
 
         {
             HANDLERS.put(Constants.METHOD, new AttributeWriter<EncryptionData>() {
@@ -299,13 +304,14 @@ abstract class MediaPlaylistTagWriter extends ExtTagWriter {
 
         @Override
         public void doWrite(TagWriter tagWriter, Playlist playlist, MediaPlaylist mediaPlaylist) throws IOException, ParseException {
-            if (mediaPlaylist.getTracks().size() > 0) {
-                TrackData td = mediaPlaylist.getTracks().get(0);
-                if (td.hasEncryptionData()) {
-                    EncryptionData ed = td.getEncryptionData();
-                    writeAttributes(tagWriter, ed, HANDLERS);
-                }
+            if (mTrackData != null && mTrackData.hasEncryptionData()) {
+                writeAttributes(tagWriter, mTrackData.getEncryptionData(), HANDLERS);
             }
         }
-    };
+
+        void writeTrackData(TagWriter tagWriter, Playlist playlist, TrackData trackData) throws IOException, ParseException {
+            mTrackData = trackData;
+            write(tagWriter, playlist);
+        }
+    }
 }

--- a/src/main/java/com/iheartradio/m3u8/SectionWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/SectionWriter.java
@@ -1,0 +1,9 @@
+package com.iheartradio.m3u8;
+
+import com.iheartradio.m3u8.data.Playlist;
+
+import java.io.IOException;
+
+interface SectionWriter {
+    void write(TagWriter tagWriter, Playlist playlist) throws IOException, ParseException;
+}


### PR DESCRIPTION
@samek Before, only the first `EXT-X-KEY` data would be written by the writer. With these changes, the encryption data on each media segment should be properly written.

Would you be able to build from the source on this branch to test it out?

I'm not the most familiar with the writer side of things, so I want to make sure this fixes the issue you are seeing.

#35 