### PR TITLE
Support floating point segment length duration for HLS PlaylistV3

### DIFF
--- a/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
@@ -210,7 +210,7 @@ abstract class MediaPlaylistTagWriter extends ExtTagWriter {
     private static void writeExtinf(TagWriter tagWriter, Playlist playlist, TrackData trackData) throws IOException {
         final StringBuilder builder = new StringBuilder();
 
-        if (playlist.getCompatibilityVersion() <= 3) {
+        if (playlist.getCompatibilityVersion() < 3) {
             builder.append(Integer.toString((int) trackData.getTrackInfo().duration));
         } else {
             builder.append(Float.toString(trackData.getTrackInfo().duration));


### PR DESCRIPTION
I am using open-m3u8 for parsing HLS manifest and transforming it.  I noticed that for Playlist Version 3 (#EXT-X-VERSION:3) , the HLS Specification says it allows for segment duration to be specified as floating point duration.  However in the code I found out that floating point duration is allowed only for version 4 and above.   This PullRequest is to fix this.

Here is a reference to HLS Spec :
https://developer.apple.com/library/content/qa/qa1752/_index.html
