### PR TITLE
Use all fields in MasterPlaylist::buildUpon

### DIFF
--- a/src/main/java/com/iheartradio/m3u8/data/MasterPlaylist.java
+++ b/src/main/java/com/iheartradio/m3u8/data/MasterPlaylist.java
@@ -37,7 +37,7 @@ public class MasterPlaylist {
     }
 
     public Builder buildUpon() {
-        return new Builder(mPlaylists, mMediaData);
+        return new Builder(mPlaylists, mIFramePlaylists, mMediaData, mUnknownTags);
     }
     
     @Override
@@ -78,6 +78,13 @@ public class MasterPlaylist {
         private List<String> mUnknownTags;
 
         public Builder() {
+        }
+
+        private Builder(List<PlaylistData> playlists, List<IFrameStreamInfo> iFramePlaylists, List<MediaData> mediaData, List<String> unknownTags) {
+            mPlaylists = playlists;
+            mIFramePlaylists = iFramePlaylists;
+            mMediaData = mediaData;
+            mUnknownTags = unknownTags;
         }
 
         private Builder(List<PlaylistData> playlists, List<MediaData> mediaData) {


### PR DESCRIPTION
Hi,

I've noticed that the buildUpon method for MasterPlaylist doesn't preserve mIFramePlaylists and mUnknownTags. This PR fixes that. I added a new MasterPlaylist.Builder constructor to avoid breaking the current api.

This library is awesome! Thanks 👍 