### PR TITLE
Fix equals and hashCode methods in PlaylistData

### DIFF
--- a/src/main/java/com/iheartradio/m3u8/data/PlaylistData.java
+++ b/src/main/java/com/iheartradio/m3u8/data/PlaylistData.java
@@ -29,7 +29,7 @@ public class PlaylistData {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), mStreamInfo);
+        return Objects.hash(mUri, mStreamInfo);
     }
 
     @Override
@@ -39,8 +39,7 @@ public class PlaylistData {
         }
 
         PlaylistData other = (PlaylistData) o;
-        
-        return super.equals(other) && Objects.equals(mStreamInfo, other.mStreamInfo);
+        return Objects.equals(mUri, other.mUri) && Objects.equals(mStreamInfo, other.mStreamInfo);
     }
 
     @Override


### PR DESCRIPTION
The equals and hashCode methods for PlaylistData are broken since they use super.hashCode and super.equals, i.e. java.lang.Object. This makes it hard to check equality between Playlists. Here's a fix for that!