### PR TITLE
Comma after extinf tag

### DIFF
--- a/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
@@ -216,8 +216,9 @@ abstract class MediaPlaylistTagWriter extends ExtTagWriter {
             builder.append(Float.toString(trackData.getTrackInfo().duration));
         }
 
+	builder.append(Constants.COMMA);
         if (trackData.getTrackInfo().title != null) {
-            builder.append(Constants.COMMA).append(trackData.getTrackInfo().title);
+            builder.append(trackData.getTrackInfo().title);
         }
 
         tagWriter.writeTag(Constants.EXTINF_TAG, builder.toString());

--- a/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
@@ -216,7 +216,7 @@ abstract class MediaPlaylistTagWriter extends ExtTagWriter {
             builder.append(Float.toString(trackData.getTrackInfo().duration));
         }
 
-	builder.append(Constants.COMMA);
+	 builder.append(Constants.COMMA);
         if (trackData.getTrackInfo().title != null) {
             builder.append(trackData.getTrackInfo().title);
         }


### PR DESCRIPTION
Add comma separator at the end of #EXTINF tag line even if title is not present.

Without the comma separator, I found out that HLS Playback fails for some players which expect a comma at the end of EXTINF tag.

Here is the link to the HLS spec:

https://tools.ietf.org/html/draft-pantos-http-live-streaming-20#section-4.3.2.1