### PR TITLE
Allow v5 tags like keyformat and keyformatversion to be optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ idea {
 group 'com.iheartradio.m3u8'
 archivesBaseName = 'open-m3u8'
 sourceCompatibility = 1.7
-version '0.2.6'
+version '0.2.7-SNAPSHOT'
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'

--- a/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/MediaPlaylistTagWriter.java
@@ -274,7 +274,7 @@ abstract class MediaPlaylistTagWriter extends ExtTagWriter {
                 @Override
                 public String write(EncryptionData encryptionData) throws ParseException {
                     //TODO check for version 5
-                    return WriteUtil.writeQuotedString(encryptionData.getKeyFormat(), getTag());
+                    return WriteUtil.writeQuotedString(encryptionData.getKeyFormat(), getTag(), true);
                 }
             });
 
@@ -287,7 +287,7 @@ abstract class MediaPlaylistTagWriter extends ExtTagWriter {
                 @Override
                 public String write(EncryptionData encryptionData) throws ParseException {
                     //TODO check for version 5
-                    return WriteUtil.writeQuotedString(WriteUtil.join(encryptionData.getKeyFormatVersions(), Constants.LIST_SEPARATOR), getTag());
+                    return WriteUtil.writeQuotedString(WriteUtil.join(encryptionData.getKeyFormatVersions(), Constants.LIST_SEPARATOR), getTag(), true);
                 }
             });
         }

--- a/src/main/java/com/iheartradio/m3u8/WriteUtil.java
+++ b/src/main/java/com/iheartradio/m3u8/WriteUtil.java
@@ -35,23 +35,30 @@ public class WriteUtil {
     }
 
     public static String writeQuotedString(String unquotedString, String tag) throws ParseException {
-        final StringBuilder builder = new StringBuilder(unquotedString.length() + 2);
-        builder.append("\"");
-        
-        for (int i = 0; i < unquotedString.length(); ++i) {
-            final char c = unquotedString.charAt(i);
-    
-            if (i == 0 && ParseUtil.isWhitespace(c)) {
-                throw new ParseException(ParseExceptionType.ILLEGAL_WHITESPACE, tag);
-            } else if (c == '"') {
-                builder.append('\\').append(c);
-            } else {
-                builder.append(c);
+        return writeQuotedString(unquotedString, tag, false);
+    }
+    public static String writeQuotedString(String unquotedString, String tag, boolean optional) throws ParseException {
+        if (unquotedString != null || !optional) {
+            final StringBuilder builder = new StringBuilder(unquotedString.length() + 2);
+            builder.append("\"");
+
+            for (int i = 0; i < unquotedString.length(); ++i) {
+                final char c = unquotedString.charAt(i);
+
+                if (i == 0 && ParseUtil.isWhitespace(c)) {
+                    throw new ParseException(ParseExceptionType.ILLEGAL_WHITESPACE, tag);
+                } else if (c == '"') {
+                    builder.append('\\').append(c);
+                } else {
+                    builder.append(c);
+                }
             }
+
+            builder.append("\"");
+            return builder.toString();
         }
-        
-        builder.append("\"");
-        return builder.toString();
+
+        return "\"\"";
     }
 
     public static String encodeUri(String decodedUri) throws ParseException {

--- a/src/test/java/com/iheartradio/m3u8/WriteUtilTest.java
+++ b/src/test/java/com/iheartradio/m3u8/WriteUtilTest.java
@@ -1,0 +1,27 @@
+package com.iheartradio.m3u8;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class WriteUtilTest {
+
+    @Test
+    public void writeQuotedStringShouldIgnoreNullTagValueForOptionalFields() throws Exception {
+            String outputString =WriteUtil.writeQuotedString(null,"some-key", true);
+
+            assertThat(outputString,is("\"\""));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void writeQuotedStringShouldNotIgnoreNullTagValue() throws Exception {
+            WriteUtil.writeQuotedString(null,"some-key");
+    }
+
+    @Test
+    public void writeQuotedStringShouldNotIgnoreSuppliedOptionalValue() throws Exception {
+            assertThat(WriteUtil.writeQuotedString("blah","some-key"),is("\"blah\""));
+    }
+
+}


### PR DESCRIPTION
Great library folks!

Just made some changes to ensure that keyformat and keyformatversions both optional tags pre v5 can be ignored where necessary. 

Added some tests to the WriteUtils.