### PR TITLE
Enable unknown tags when writing playlists

### DIFF
--- a/src/main/java/com/iheartradio/m3u8/ExtTagWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/ExtTagWriter.java
@@ -63,7 +63,7 @@ abstract class ExtTagWriter implements IExtTagWriter {
             List<String> unknownTags;
             if (playlist.hasMasterPlaylist() && playlist.getMasterPlaylist().hasUnknownTags()) {
                 unknownTags = playlist.getMasterPlaylist().getUnknownTags();
-            } else if (playlist.getMediaPlaylist().hasUnknownTags()) {
+            } else if (playlist.hasMediaPlaylist() && playlist.getMediaPlaylist().hasUnknownTags()) {
                 unknownTags = playlist.getMediaPlaylist().getUnknownTags();
             } else {
                 unknownTags = Collections.emptyList();

--- a/src/main/java/com/iheartradio/m3u8/ExtendedM3uWriter.java
+++ b/src/main/java/com/iheartradio/m3u8/ExtendedM3uWriter.java
@@ -9,7 +9,7 @@ import java.util.List;
 import com.iheartradio.m3u8.data.Playlist;
 
 class ExtendedM3uWriter extends Writer {
-    private List<SectionWriter> mExtTagWriter = new ArrayList<SectionWriter>();
+    private final List<SectionWriter> mExtTagWriter = new ArrayList<SectionWriter>();
 
     public ExtendedM3uWriter(OutputStream outputStream, Encoding encoding) {
         super(outputStream, encoding);
@@ -17,6 +17,7 @@ class ExtendedM3uWriter extends Writer {
         putWriters(
                 ExtTagWriter.EXTM3U_HANDLER,
                 ExtTagWriter.EXT_X_VERSION_HANDLER,
+                ExtTagWriter.EXT_UNKNOWN_HANDLER,
                 MediaPlaylistTagWriter.EXT_X_PLAYLIST_TYPE,
                 MediaPlaylistTagWriter.EXT_X_TARGETDURATION,
                 MediaPlaylistTagWriter.EXT_X_START,


### PR DESCRIPTION
When a media playlist builder is configured to use unknown tags (MediaPlaylist.Builder().withUnknownTags(...)) the unknown tags will not be written using the ExtendedM3uWriter.
This commit enables the EXT_UNKNOWN_HANDLER and fixes a potential NullPointerException.